### PR TITLE
fixed bug where isActive() returned nil on active pages

### DIFF
--- a/system/core/core.php
+++ b/system/core/core.php
@@ -741,7 +741,7 @@ class Yellow_Toolbox
 	static function getRequestLocation()
 	{
 		$uri = $_SERVER["REQUEST_URI"];
-		return ($pos = strposu($uri, '?')) ? substru($uri, 0, $pos) : $uri;
+		return self::normaliseLocation(($pos = strposu($uri, '?')) ? substru($uri, 0, $pos) : $uri);
 	}
 	
 	// Return arguments from current HTTP request


### PR DESCRIPTION
To recreate the bug put yellow in a folder with e.g. a space in its name.
The resulting "%20" urlencoded space will not parse against $location.
I added normaliseLocation() into getRequestLocation() to fix this.
Please check if this could break things else where.... If so put getRequestLocation() into isActiveLocation() on line 826:
$currentLocation = substru(self::normaliseLocation(self::getRequestLocation()), strlenu($baseLocation));
