### PR TITLE
Added map and scss to the isSafeFile function

### DIFF
--- a/system/extensions/core.php
+++ b/system/extensions/core.php
@@ -1806,7 +1806,7 @@ class YellowLookup {
     
     // Check if file is a well-known file type
     public function isSafeFile($fileName) {
-        return preg_match("/\.(css|gif|ico|js|jpg|png|svg|woff|woff2)$/", $fileName);
+        return preg_match("/\.(css|gif|ico|js|jpg|map|png|scss|svg|woff|woff2)$/", $fileName);
     }
     
     // Check if file is valid


### PR DESCRIPTION
When creating a stylesheet with SASS, a .map is created in addition to the CSS file, in which it is broken down which element, class or ID is described in which SCSS file. For this to work, these file types must be accessible.