### PR TITLE
found and fixed a bug in `getDateRelative()`

### DIFF
--- a/system/extensions/core.php
+++ b/system/extensions/core.php
@@ -876,9 +876,10 @@ class YellowLanguage {
     
     // Return Unix time as date, relative to today
     public function getDateRelative($timestamp, $format, $daysLimit, $language = "") {
-        $timeDifference = time() - $timestamp;
-        $days = abs(intval($timeDifference/86400));
-        $key = $timeDifference>=0 ? "coreDatePast" : "coreDateFuture";
+        $today = strtotime(date('Y-m-d')); // Today's date without time information
+        $dateDifference = $today - strtotime(date('Y-m-d', $timestamp)); // Difference in days between today and the specified date
+        $days = abs(intval($dateDifference/86400));
+        $key = $dateDifference>=0 ? "coreDatePast" : "coreDateFuture";
         $tokens = preg_split("/\s*,\s*/", $this->getText($key, $language));
         if (count($tokens)>=8) {
             if ($days<=$daysLimit || $daysLimit==0) {


### PR DESCRIPTION
The bug in the function `getDateRelative()` results in a page created at 18:00 being output at 13:00 on the following day `today` as relative date, which is wrong.

I have modified `getDateRelative()` so that the basis for calculating the time difference is the date and not the time (86400s (24h)) so now the date of the publication is checked against today's date and outputs the correct relative date.