### PR TITLE
Publish extension Backtotop

### DIFF
--- a/system/extensions/update-latest.ini
+++ b/system/extensions/update-latest.ini
@@ -12,6 +12,19 @@ system/extensions/anchor.php: anchor.php, create, update
 system/extensions/anchor.css: anchor.css, create, update
 system/extensions/anchor-stack.svg: anchor-stack.svg, create, update
 
+Extension: Backtotop
+Version: 0.8.22
+Description: Back-to-top link.
+DownloadUrl: https://github.com/GiovanniSalmeri/yellow-backtotop/archive/refs/heads/main.zip
+DocumentationUrl: https://github.com/GiovanniSalmeri/yellow-backtotop
+DocumentationLanguage: en
+Developer: Giovanni Salmeri
+Status: public
+Tag: feature
+system/extensions/backtotop.php: backtotop.php, create, update
+system/extensions/backtotop.js: backtotop.js, create, update
+system/extensions/backtotop.css: backtotop.css, create, update
+
 Extension: Berlin
 Version: 0.8.14
 Description: Berlin is a theme inspired by Dieter Rams.


### PR DESCRIPTION
The repository of Backtotop is https://github.com/GiovanniSalmeri/yellow-backtotop
The extension was kindly reviewed by @markseuffert. Thank you very much!