### PR TITLE
Updated yellow-anchor

### DIFF
--- a/system/extensions/update-available.ini
+++ b/system/extensions/update-available.ini
@@ -1,13 +1,13 @@
 # Datenstrom Yellow update settings for available extensions
 
 Extension: Anchor
-Version: 0.9.2
+Version: 0.9.3
 Description: Show anchor links next to headings.
 Developer: Robert Pfotenhauer
 Tag: anchors, headings, feature
 DownloadUrl: https://github.com/pftnhr/yellow-anchor/archive/refs/heads/main.zip
 DocumentationUrl: https://github.com/pftnhr/yellow-anchor
-Published: 2024-08-19 10:43:22
+Published: 2025-02-26 10:50:45
 Status: available
 system/workers/anchor.php: anchor.php, create, update
 system/workers/anchor.css: anchor.css, create, update


### PR DESCRIPTION
Removed trailing slash from `<link rel="stylesheet" ...> because trailing slash on void elements has no effect and interacts badly with unquoted attribute values.

See https://github.com/validator/validator/wiki/Markup-»-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing and https://github.com/validator/validator/wiki/Markup-»-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values